### PR TITLE
Fixes #2

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -9,18 +9,19 @@ const activate = ({ subscriptions }) => {
   let toggleCommand = registerCommand(`${namespace}.toggle`, (value) => {
     const config = getConfiguration('explorer')
     const isGlobal = config.inspect(configKey).workspaceValue === undefined
+    let newValue = value
 
-    if (value === undefined) {
-      value = config.get(configKey) ? false : true  
+    if (newValue === undefined) {
+      newValue = config.get(configKey) ? false : true  
     }
 
-    if (!value && isGlobal) { 
-      //Use undefined only global setting, otherwise it removes the setting and it wont restore to the workspace when toggled back
-      value = undefined
+    if (!newValue && isGlobal) { 
+      // Use undefined only global setting, otherwise it removes the setting and it won't restore to the workspace when toggled back
+      newValue = undefined
     }
 
-    config.update(configKey, value, isGlobal)
-    setContext(value)
+    config.update(configKey, newValue, isGlobal)
+    setContext(newValue)
   })
 
   let hideCommand = registerCommand(`${namespace}.hide`, () => {

--- a/extension.js
+++ b/extension.js
@@ -11,15 +11,36 @@ const activate = ({ subscriptions }) => {
     const currentValue = config.get(configKey)
     const newValue = currentValue ? undefined : true
     config.update(configKey, newValue, true)
+    setContext(newValue)
   })
 
   let hideCommand = registerCommand(`${namespace}.hide`, () => {
     getConfiguration('explorer').update(configKey, true, true)
+    setContext(true)
   })
 
   let showCommand = registerCommand(`${namespace}.show`, () => {
     getConfiguration('explorer').update(configKey, undefined, true)
+    setContext(undefined)
   })
+
+  let setContext = (state) => { 
+    vscode.commands.executeCommand('setContext', `${namespace}.toggled`, state)
+  }
+
+  const config = getConfiguration('explorer')
+  setContext(config.get(configKey) || undefined);
+
+  subscriptions.push(vscode.Disposable.from(
+      vscode.workspace.onDidChangeConfiguration((e) => {
+        if (e.affectsConfiguration(`explorer.${configKey}`)) {
+          const config = getConfiguration('explorer')
+          setContext(config.get(configKey) || undefined);
+        }
+      })
+    )
+  )
+
 
   subscriptions.push(toggleCommand)
   subscriptions.push(hideCommand)

--- a/package.json
+++ b/package.json
@@ -43,12 +43,12 @@
         {
           "command": "explorer-gitignore.show",
           "group": "navigation@21",
-          "when": "view == 'workbench.explorer.fileView' && explorer-gitignore.toggled"
+          "when": "view == 'workbench.explorer.fileView' && explorer-gitignore.hidden"
         },
         {
           "command": "explorer-gitignore.hide",
           "group": "navigation@21",
-          "when": "view == 'workbench.explorer.fileView' && !explorer-gitignore.toggled"
+          "when": "view == 'workbench.explorer.fileView' && !explorer-gitignore.hidden"
         }
       ]
     }

--- a/package.json
+++ b/package.json
@@ -29,13 +29,29 @@
       },
       {
         "command": "explorer-gitignore.hide",
-        "title": "Hide Git-ignored files"
+        "title": "Hide Git-ignored files",
+        "icon": "$(eye-closed)"
       },
       {
         "command": "explorer-gitignore.show",
-        "title": "Show Git-ignored files"
+        "title": "Show Git-ignored files",
+        "icon": "$(eye)"
       }
-    ]
+    ],
+    "menus": {
+      "view/title": [
+        {
+          "command": "explorer-gitignore.show",
+          "group": "navigation@21",
+          "when": "view == 'workbench.explorer.fileView' && explorer-gitignore.toggled"
+        },
+        {
+          "command": "explorer-gitignore.hide",
+          "group": "navigation@21",
+          "when": "view == 'workbench.explorer.fileView' && !explorer-gitignore.toggled"
+        }
+      ]
+    }
   },
   "keybindings": [
     {


### PR DESCRIPTION
Adds the icon to the tree view, not sure if the eye should be open when showing the files or closed, thoughts ?

Also added detecting if the config is changed manually. It's a bit redundant when it's changed via the commands as it sets context again, but without setting it via the commands there was a slight lag with the icon changing when clicking it.

Also adds support for workspace settings, which it leaves as false rather than undefined so the setting stays if they toggle back